### PR TITLE
feat: add connection pool

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        rust: [nightly, stable, 1.45.0]
+        os: [ ubuntu-latest ]
+        rust: [ nightly, stable ]
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.3.0 (2021-10-23)
+
+**Features**
+
+* Add `deadpool` pool connection, which somehow reverts the changes from version `1.1.0`.  
+* Refactor the `AmqpResult` type to include errors from both `lapin` and `deadpool`.
+
+**Breaking**
+
+* Including an async pool connection implies using an async runtime, so as of this release, this library will include
+a couple of features to specify the runtime you want to use (tokio or async_std).
+
 ## 1.2.0 (2021-05-21)
 
 **Features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,27 @@
 [package]
 name = "amqp-manager"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Adrian Benavides"]
 edition = "2018"
-description = "Lapin wrapper that encapsulates the use of channels and provides some helpful methods"
+description = "Lapin wrapper that encapsulates the use of connections/channels and creation of amqp objects"
 repository = "https://github.com/adrianbenavides/amqp-manager"
 keywords = ["lapin", "amqp"]
 license = "MIT"
 
+[features]
+default = ["rt_tokio_1"]
+rt_tokio_1 = ["deadpool-lapin/rt_tokio_1", "tokio-amqp"]
+rt_async-std_1 = ["deadpool-lapin/rt_async-std_1", "async-amqp"]
+
 [dependencies]
+async-amqp = { version = "=1.2", optional = true }
+deadpool-lapin = { version = "=0.9", default-features = false, features = ["rt_tokio_1"] }
 lapin = { version = "=1.7", default-features = false, features = ["rustls"] }
+thiserror = "=1.0"
+tokio-amqp = { version = "=1.0", optional = true }
 
 [dev-dependencies]
+deadpool-lapin = "=0.9"
 dotenv = "0.15"
 futures = "0.3"
 once_cell = "1"
@@ -19,4 +29,3 @@ rand = "0.8"
 serde = "1"
 serde_json = "1"
 tokio = { version = "=1", features = ["rt-multi-thread", "macros", "time"] }
-tokio-amqp = { version = "=1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@
 [![audit](https://github.com/adrianbenavides/amqp-manager/workflows/Audit/badge.svg)](https://github.com/adrianbenavides/amqp-manager/actions)
 [![crates.io-license](https://img.shields.io/crates/l/amqp-manager)](LICENSE)
 
-[Lapin](https://github.com/CleverCloud/lapin) wrapper that encapsulates the use of connections/channels and provides some 
-helpful methods making it easier to use and less error prone. 
+[Lapin](https://github.com/CleverCloud/lapin) wrapper that encapsulates the use of connections/channels and creation of amqp objects.
 
 ## Usage
 
 ```rust
 use amqp_manager::prelude::*;
+use deadpool_lapin::{Config, Runtime};
 use futures::FutureExt;
-use tokio_amqp::LapinTokioExt;
 
 #[tokio::main]
 async fn main() {
-    let manager = AmqpManager::new("amqp://guest:guest@127.0.0.1:5672//", ConnectionProperties::default().with_tokio());
-    let conn = manager.connect().await.unwrap();
-    let session = AmqpManager::create_session_with_confirm_select(&conn)
+    let pool = Config {
+        url: Some("amqp://guest:guest@127.0.0.1:5672//".to_string()),
+        ..Default::default()
+    }
+        .create_pool(Some(Runtime::Tokio1))
+        .expect("Should create DeadPool instance");
+    let manager = AmqpManager::new(pool);
+    let session = manager
+        .create_session_with_confirm_select()
         .await
         .expect("Should create AmqpSession instance");
 
@@ -68,6 +73,4 @@ async fn main() {
 
 ## Build-time Requirements
 
-The crate is tested on `ubuntu-latest` against the following rust versions: nightly, beta, stable and 1.45.0.
-It is possible that it works with older versions as well but this is not tested.
-Please see the details of the lapin crate about its requirements.
+Please see the details of the lapin and deadpool crates about their requirements.

--- a/examples/pubsub_tokio.rs
+++ b/examples/pubsub_tokio.rs
@@ -1,12 +1,18 @@
 use amqp_manager::prelude::*;
+use deadpool_lapin::{Config, Runtime};
 use futures::FutureExt;
-use tokio_amqp::LapinTokioExt;
 
 #[tokio::main]
 async fn main() {
-    let manager = AmqpManager::new("amqp://guest:guest@127.0.0.1:5672//", ConnectionProperties::default().with_tokio());
-    let conn = manager.connect().await.unwrap();
-    let session = AmqpManager::create_session_with_confirm_select(&conn)
+    let pool = Config {
+        url: Some("amqp://guest:guest@127.0.0.1:5672//".to_string()),
+        ..Default::default()
+    }
+    .create_pool(Some(Runtime::Tokio1))
+    .expect("Should create DeadPool instance");
+    let manager = AmqpManager::new(pool);
+    let session = manager
+        .create_session_with_confirm_select()
         .await
         .expect("Should create AmqpSession instance");
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
+pub use deadpool_lapin;
 pub use lapin;
 pub use lapin::message::{BasicReturnMessage, Delivery, DeliveryResult};
 pub use lapin::options::{


### PR DESCRIPTION
This PR adds a `deadpool` pool connection to reuse connections to create sessions, which somehow reverts the changes from version `1.1.0` with the difference that `deadpool` seems to work fine and `mobc` didn't.

Including an async pool connection implies using an async runtime, so as of this release, this library will include a couple of features to specify the runtime you want to use (tokio or async_std) to include the necessary dependencies.

It also refactors the `AmqpResult` type to include errors from both `lapin` and `deadpool`.

Finally, it adds a couple of tests to show how to reuse a single connection for multiple sessions and how to use multiple connections with each connection creating multiple sessions.

## Related
* https://github.com/adrianbenavides/amqp-manager/pull/16